### PR TITLE
Improve PHPUnit assertEquals assertion

### DIFF
--- a/tests/Formatter/Exception/ResponseExceptionJsonFormatterTest.php
+++ b/tests/Formatter/Exception/ResponseExceptionJsonFormatterTest.php
@@ -9,7 +9,7 @@ use Psr\Http\Message\RequestInterface;
 
 class ResponseExceptionJsonFormatterTest extends ResponseExceptionArrayFormatterTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Formatter/Request/RequestArrayFormatterTest.php
+++ b/tests/Formatter/Request/RequestArrayFormatterTest.php
@@ -9,7 +9,7 @@ class RequestArrayFormatterTest extends RequestFormatterTest
     public function implementAssertionForUserAgent($response)
     {
         $this->assertArrayHasKey("user-agent", $response);
-        $this->assertEquals(self::USER_AGENT, $response['user-agent']);
+        $this->assertSame(self::USER_AGENT, $response['user-agent']);
     }
 
     public function implementAssertionForRequestMethodIsIncluded($response)
@@ -21,19 +21,19 @@ class RequestArrayFormatterTest extends RequestFormatterTest
     {
         $this->assertArrayHasKey("headers", $response);
         $this->assertArrayHasKey("foo", $response['headers']);
-        $this->assertEquals(["bar"], $response['headers']['foo']);
+        $this->assertSame(["bar"], $response['headers']['foo']);
     }
 
     public function implementAssertionForSameHeadersWithMultipleValues($response)
     {
-        $this->assertEquals(["bar", "baz"], $response['headers']['foo']);
+        $this->assertSame(["bar", "baz"], $response['headers']['foo']);
     }
 
     public function implementAssertionForRequestContainingAllHeaders($response)
     {
         $this->assertArrayHasKey("headers", $response);
-        $this->assertEquals(["bar"], $response['headers']['foo']);
-        $this->assertEquals(["baz"], $response['headers']['baz']);
+        $this->assertSame(["bar"], $response['headers']['foo']);
+        $this->assertSame(["baz"], $response['headers']['baz']);
     }
 
     public function implementAssertionForGetRequestWithQueryString($response)
@@ -44,66 +44,66 @@ class RequestArrayFormatterTest extends RequestFormatterTest
 
     public function implementAssertionForGetRequestWithRequestBody($response)
     {
-        $this->assertEquals('GET', $response['method']);
+        $this->assertSame('GET', $response['method']);
         $this->assertArrayHasKey('body', $response);
-        $this->assertEquals('foo=bar&hello=world', $response['body']);
+        $this->assertSame('foo=bar&hello=world', $response['body']);
     }
 
     public function implementAssertionForPostRequest($response)
     {
-        $this->assertEquals('POST', $response['method']);
-        $this->assertNotEquals('GET', $response['method']);
+        $this->assertSame('POST', $response['method']);
+        $this->assertNotSame('GET', $response['method']);
         $this->assertArrayHasKey('body', $response);
-        $this->assertEquals('foo=bar&hello=world', $response['body']);
+        $this->assertSame('foo=bar&hello=world', $response['body']);
     }
 
     public function implementAssertionForHeadRequest($response)
     {
-        $this->assertEquals('HEAD', $response['method']);
+        $this->assertSame('HEAD', $response['method']);
     }
 
     public function implementAssertionForOptionsRequest($response)
     {
-        $this->assertEquals('OPTIONS', $response['method']);
+        $this->assertSame('OPTIONS', $response['method']);
     }
 
     public function implementAssertionForDeleteRequest($response)
     {
-        $this->assertEquals('DELETE', $response['method']);
+        $this->assertSame('DELETE', $response['method']);
     }
 
     public function implementAssertionForPutRequest($response)
     {
-        $this->assertEquals('PUT', $response['method']);
+        $this->assertSame('PUT', $response['method']);
         $this->assertArrayHasKey('body', $response);
-        $this->assertEquals('foo=bar&hello=world', $response['body']);
+        $this->assertSame('foo=bar&hello=world', $response['body']);
     }
 
     public function implementAssertionForPatchRequest($response)
     {
-        $this->assertEquals('PATCH', $response['method']);
+        $this->assertSame('PATCH', $response['method']);
         $this->assertArrayHasKey('body', $response);
-        $this->assertEquals('foo=bar&hello=world', $response['body']);
+        $this->assertSame('foo=bar&hello=world', $response['body']);
     }
 
     public function implementAssertionForProperBodyReading($response, $originalContent)
     {
-        $this->assertEquals($originalContent, $response['body']);
-        $this->assertEquals('foo=bar&hello=world', $response['body']);
-        $this->assertEquals("PUT", $response['method']);
+        $this->assertSame($originalContent, $response['body']);
+        $this->assertSame('foo=bar&hello=world', $response['body']);
+        $this->assertSame("PUT", $response['method']);
     }
 
     public function implementAssertionForExtractBodyArgument($response)
     {
-        $this->assertEquals('foo=bar&hello=world', $response['body']);
+        $this->assertSame('foo=bar&hello=world', $response['body']);
     }
 
     public function implementAssertionForCookieIsParsedFromRequest($response)
     {
         $this->assertArrayHasKey('cookies', $response);
         $this->assertCount(1, $response['cookies']);
-        $this->assertEquals('cookie-name', $response['cookies'][0]['name']);
-        $this->assertEquals('cookie-value', $response['cookies'][0]['value']);
+        $this->assertSame('cookie-name', $response['cookies'][0]['name']);
+        $this->assertSame('cookie-value', $response['cookies'][0]['value']);
 
         $keys = [
             'name',

--- a/tests/Formatter/Request/RequestCurlFormatterTest.php
+++ b/tests/Formatter/Request/RequestCurlFormatterTest.php
@@ -47,7 +47,7 @@ class RequestCurlFormatterTest extends RequestFormatterTest
     {
         $expected = sprintf("curl --url 'http://example.local?foo=bar' -A '%s'", self::USER_AGENT);
 
-        $this->assertEquals($expected, $response);
+        $this->assertSame($expected, $response);
     }
 
     public function implementAssertionForGetRequestWithRequestBody($response)
@@ -110,7 +110,7 @@ class RequestCurlFormatterTest extends RequestFormatterTest
         $this->formatter->setCommandLineLength(10);
         $response = $this->formatter->format($this->createRequest('get', '/', '', ['foo' => 'bar']));
 
-        $this->assertEquals(3, substr_count($response, "\n"));
+        $this->assertSame(3, substr_count($response, "\n"));
     }
 
     public function testMinimumLineLength()
@@ -121,7 +121,7 @@ class RequestCurlFormatterTest extends RequestFormatterTest
             $this->createRequest('get', '/', '', ['user-agent' => '', 'foo' => 'bar'])
         );
 
-        $this->assertEquals(0, substr_count($response, "\n"));
+        $this->assertSame(0, substr_count($response, "\n"));
     }
 
     public function testDoesNotIncludeEmptyValue()
@@ -132,7 +132,7 @@ class RequestCurlFormatterTest extends RequestFormatterTest
             $this->createRequest('get', '/', '', ['user-agent' => '', 'foo' => 'bar'])
         );
 
-        $this->assertEquals(2, substr_count($response, "\n"));
+        $this->assertSame(2, substr_count($response, "\n"));
     }
 
     public function testBasicCurlRequest()
@@ -140,6 +140,6 @@ class RequestCurlFormatterTest extends RequestFormatterTest
         $response = $this->formatter->format($this->createRequest('get', 'http://example.local'));
         $expected = sprintf("curl --url 'http://example.local' -A '%s'", self::USER_AGENT);
 
-        $this->assertEquals($expected, $response);
+        $this->assertSame($expected, $response);
     }
 }

--- a/tests/Formatter/Request/RequestJsonFormatterTest.php
+++ b/tests/Formatter/Request/RequestJsonFormatterTest.php
@@ -6,7 +6,7 @@ use Psr\Http\Message\RequestInterface;
 
 class RequestJsonFormatterTest extends RequestArrayFormatterTest
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Formatter/Response/ResponseArrayFormatterTest.php
+++ b/tests/Formatter/Response/ResponseArrayFormatterTest.php
@@ -111,7 +111,7 @@ class ResponseArrayFormatterTest extends FormatterTestCase
 
         $format = $this->formatter->format($request, $response);
 
-        $this->assertEquals(['foo'], $format['headers']['x-foo']);
+        $this->assertSame(['foo'], $format['headers']['x-foo']);
     }
 
     public function testExcludesFewHeaders()

--- a/tests/Middleware/LogMiddlewareTest.php
+++ b/tests/Middleware/LogMiddlewareTest.php
@@ -19,7 +19,7 @@ class LogMiddlewareTest extends MiddlewareTestCase
         $client->send($dto->request);
 
         foreach ($logger->records as $record) {
-            $this->assertEquals(LogLevel::DEBUG, $record['level']);
+            $this->assertSame(LogLevel::DEBUG, $record['level']);
         }
     }
 
@@ -28,7 +28,7 @@ class LogMiddlewareTest extends MiddlewareTestCase
         $dto = $this->objectFactory(['log_level' => 'info',]);
 
         $dto->client->send($dto->request);
-        $this->assertEquals(LogLevel::INFO, $dto->logger->records[0]['level']);
+        $this->assertSame(LogLevel::INFO, $dto->logger->records[0]['level']);
     }
 
     public function testUserCanDisableAllTypesOfLogging()


### PR DESCRIPTION
# Changed log
- Using the `protected function setUp` PHPUnit fixtures to correct method name.
- Using the `assertSame` and `assertNotSame` to make assert equals strict.