### PR TITLE
Allow psr/log 2.x and 3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=7.1",
         "guzzlehttp/guzzle": "^6.2|^7.1",
         "guzzlehttp/promises": "^1.5",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5.15|^8.4|^9.0",


### PR DESCRIPTION
I'm being blocked by expectation that psr/log 1 is only supported. I'm not an expert here, not sure if this would be a problem?

If merged I would be very thankful if new version can be pushed tagged too